### PR TITLE
Added missing include of <stdio.h> to libcdata.h for the functions which have FILE* as a parameter

### DIFF
--- a/include/libcdata.h.in
+++ b/include/libcdata.h.in
@@ -28,6 +28,8 @@
 #include <libcdata/features.h>
 #include <libcdata/types.h>
 
+#include <stdio.h>
+
 #if defined( __cplusplus )
 extern "C" {
 #endif


### PR DESCRIPTION
libcdata.h declares functions which have FILE\* parameters but does not include <stdio.h>. This patches that problem.
